### PR TITLE
making dd command macos compatible

### DIFF
--- a/pi/provision.sh
+++ b/pi/provision.sh
@@ -85,7 +85,7 @@ pushd "${script_dir}" > /dev/null
     exit 1
   fi
 
-  sudo dd if="./tmp/hypriotos-rpi-v${os_version}.img" of="${sd_device_path}" bs=1M
+  sudo dd if="./tmp/hypriotos-rpi-v${os_version}.img" of="${sd_device_path}" bs=1048576
 
   sleep 5 # give drive time to mount
   os_mount="$(mount | grep "${sd_device_path}.*HypriotOS" | awk '{print $3}')"


### PR DESCRIPTION
Macos doesn't like the human readable 'bs=1M', it prefers just bytes 'bs=1048576' 

```
./submodules/k8s-pi/pi/provision.sh -d /dev/disk3 -n k8s-master -p "$(cat ~/.ssh/id_rsa.pub)"
Flashing HypriotOS 1.9.0 to SD card /dev/disk3...
dd: bs: illegal numeric value
```